### PR TITLE
Fix SGR and PIXEL mouse modes blocked by mouse_event check

### DIFF
--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -3290,7 +3290,7 @@ bool tsm_vte_handle_mouse(struct tsm_vte *vte, unsigned int cell_x,
 
 		vte_write(vte, buffer, strlen(buffer));
 		return true;
-	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR && vte->mouse_event) {
+	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR) {
 		if (event & TSM_MOUSE_EVENT_MOVED) {
 			if (cell_x == vte->mouse_last_col && cell_y == vte->mouse_last_row) {
 				return false;
@@ -3307,7 +3307,7 @@ bool tsm_vte_handle_mouse(struct tsm_vte *vte, unsigned int cell_x,
 
 		vte_write(vte, buffer, strlen(buffer));
 		return true;
-	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL && vte->mouse_event) {
+	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL) {
 		if (event == TSM_MOUSE_EVENT_MOVED) {
 			reply_flags = 35;
 			pressed = true;


### PR DESCRIPTION
# Pull Request: Fix SGR and PIXEL mouse modes blocked by mouse_event check

## Summary

This PR fixes a bug where SGR (mode 1006) and PIXEL (mode 1016) mouse modes were not working in applications like `less` and `vim` due to an incorrect condition check.

## The Bug

In `src/tsm/tsm-vte.c`, the SGR and PIXEL mode handlers check both the mouse mode AND the mouse_event flag:

```c
} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR && vte->mouse_event) {
    // SGR handling code
}
```

```c
} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL && vte->mouse_event) {
    // PIXEL handling code
}
```

**Problem:** When applications like `less` or `vim` activate SGR mouse mode, they don't always set `vte->mouse_event` first. The value remains 0, causing the condition `&& vte->mouse_event` to evaluate to false, and the SGR/PIXEL handler never executes.

## The Fix

Remove the `&& vte->mouse_event` condition from both checks:

```c
} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR) {
    // SGR handling code
}
```

```c
} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL) {
    // PIXEL handling code
}
```

**Rationale:** The `mouse_mode` check alone is sufficient. If the mode is set to SGR or PIXEL, the handler should execute. The `mouse_event` flag is used internally to filter event types (press/release/motion), but shouldn't prevent the mode handler from running.

## Test Cases

### Before the fix:
- Run `less --mouse` in kmscon → mouse wheel does NOT work
- Run `vim` with `:set mouse=a ttymouse=sgr` → mouse wheel does NOT work (in some cases)

### After the fix:
- Run `less --mouse` in kmscon → mouse wheel WORKS correctly
- Run `vim` with `:set mouse=a ttymouse=sgr` → mouse wheel WORKS correctly

## Impact

This bug affects any application using libtsm that:
1. Activates SGR or PIXEL mouse modes
2. Doesn't explicitly set mouse_event before sending mouse events
3. Common examples: `less`, `vim`, `emacs`, `nano` with mouse support

## Related Information

- SGR mode (1006) is the modern standard for mouse reporting in terminals
- It's supported by all major terminal emulators (xterm, gnome-terminal, etc.)
- This bug makes libtsm incompatible with standard terminal behavior

## Compatibility

This change has no negative impact:
- Applications that DO set mouse_event will continue to work
- Applications that DON'T set mouse_event will now work correctly
- No API changes
- Purely a bug fix
