### PR TITLE
vte: guard case 'm' (SGR) against CSI_GT prefix

### DIFF
--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -1973,7 +1973,11 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 		tsm_screen_erase_chars(vte->con, num);
 		break;
 	case 'm':
-		csi_attribute(vte);
+		/* CSI_GT ('>' prefix) marks a private/DEC sequence such as
+		 * XTMODKEYS \033[>4;1m — not an SGR attribute. Guard against
+		 * misinterpreting it as e.g. SGR 4 (underline). */
+		if (!(vte->csi_flags & CSI_GT))
+			csi_attribute(vte);
 		break;
 	case 'p':
 		if (vte->csi_flags & CSI_GT) {


### PR DESCRIPTION
## Problem

Fish 4.x (and other terminals implementing modifyOtherKeys/XTMODKEYS) send `\033[>4;1m` at **every prompt** to enable the keyboard protocol. The `>` prefix sets the `CSI_GT` flag, indicating this is a private/DEC sequence — not an SGR attribute.

`do_csi()` dispatches `case 'm':` directly to `csi_attribute()` without checking `CSI_GT`, so `\033[>4;1m` is misinterpreted as **SGR 4;1 (underline + bold)**. The result: blank terminal cells render as `_`.

This is reproducible with fish 4.x inside any kmscon/libtsm terminal.

## Fix

Add the same `CSI_GT` guard that `case 'p':` already has, one case below:

```c
case 'm':
    if (!(vte->csi_flags & CSI_GT))
        csi_attribute(vte);
    break;
```

## References

- Fish 4.x sends `\033[>4;1m` (XTMODKEYS enable) at every readline re-entry, not just startup
- `case 'p':` in the same switch already correctly guards against `CSI_GT`
- XTerm docs: `CSI > Ps m` — Set/reset key modifier options