### PR TITLE
Fix build musl

### DIFF
--- a/external/wcwidth/wcwidth.h
+++ b/external/wcwidth/wcwidth.h
@@ -3,10 +3,15 @@
 
 #include <stdlib.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int wcwidth(wchar_t ucs);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif


### PR DESCRIPTION
__BEGIN_DECLS is not define with musl C library, so revert it.

Fixes #31