### PR TITLE
selection: make sure posx and posy are valid

### DIFF
--- a/src/tsm/tsm-selection.c
+++ b/src/tsm/tsm-selection.c
@@ -144,6 +144,11 @@ void tsm_screen_selection_start(struct tsm_screen *con,
 	/* TODO: more sophisticated ageing */
 	con->age = con->age_cnt;
 
+	if (posx >= con->size_x)
+		posx = con->size_x - 1;
+	if (posy >= con->size_y)
+		posy = con->size_y - 1;
+
 	con->sel_active = true;
 	selection_set(con, &con->sel_start, posx, posy);
 	memcpy(&con->sel_end, &con->sel_start, sizeof(con->sel_end));
@@ -161,6 +166,11 @@ void tsm_screen_selection_target(struct tsm_screen *con,
 	/* TODO: more sophisticated ageing */
 	con->age = con->age_cnt;
 
+	if (posx >= con->size_x)
+		posx = con->size_x - 1;
+	if (posy >= con->size_y)
+		posy = con->size_y - 1;
+
 	selection_set(con, &con->sel_end, posx, posy);
 }
 
@@ -175,6 +185,11 @@ void tsm_screen_selection_word(struct tsm_screen *con,
 	screen_inc_age(con);
 	/* TODO: more sophisticated ageing */
 	con->age = con->age_cnt;
+
+	if (posx >= con->size_x)
+		posx = con->size_x - 1;
+	if (posy >= con->size_y)
+		posy = con->size_y - 1;
 
 	word_select(con, posx, posy);
 }


### PR DESCRIPTION
This is a tentative to fix the following crash:

 #0  0x00007f0a572da874 in calc_line_len (line=0x231) at ../libtsm/src/tsm/tsm-selection.c:188
 #1  copy_line (line=0x231, buf=buf@entry=0x5614ec13aa7b "", start=0, len=256) at ../libtsm/src/tsm/tsm-selection.c:207
 #2  0x00007f0a572dad65 in copy_lines (con=0x5614eb42c730, start=<optimized out>, end=<optimized out>, buf=0x5614ec139160 "iled on output DP-2\n00:13:24.870 [wlr] [backend/drm/atomic.c:83] connector DP-2: Atomic commit failed: Device or resource busy\n00:13:24.870 [sway/desktop/output.c:307] Page-flip failed on output DP-2\n"..., pos=6427) at ../libtsm/src/tsm/tsm-selection.c:459
 #3  tsm_screen_selection_copy (con=0x5614eb42c730, out=out@entry=0x5614eb3f2618) at ../libtsm/src/tsm/tsm-selection.c:520
 #4  0x00005614bb685484 in copy_selection (term=<optimized out>) at ../kmscon/src/kmscon_terminal.c:608
 #5  handle_pointer_button (term=0x5614eb3f24f0, ev=0x7ffc8c54e730) at ../kmscon/src/kmscon_terminal.c:666
 #6  pointer_event (input=<optimized out>, ev=0x7ffc8c54e730, data=0x5614eb3f24f0) at ../kmscon/src/kmscon_terminal.c:711
 #7  0x00005614bb688ce6 in shl_hook_call (hook=0x5614eb3f0290, parent=0x5614eb3f0220, arg=0x7ffc8c54e730) at ../kmscon/src/shl_hook.h:216
 #8  shl_hook_call (hook=0x5614eb3f0290, parent=0x5614eb3f0220, arg=0x7ffc8c54e730) at ../kmscon/src/shl_hook.h:200
 #9  pointer_dev_send_button (button=button@entry=0 '\000', pressed=<optimized out>, dbl_click=<optimized out>, dev=0x5614eb7d9270) at ../kmscon/src/uterm_input_pointer.c:60
 #10 0x00005614bb68fa67 in pointer_dev_button (dev=<optimized out>, code=272, value=0) at ../kmscon/src/uterm_input_pointer.c:188
 #11 notify_event (dev=<optimized out>, type=<optimized out>, code=272, value=0) at ../kmscon/src/uterm_input.c:61
 #12 input_data_dev (data=<optimized out>, mask=<optimized out>, fd=<optimized out>) at ../kmscon/src/uterm_input.c:104
 #13 0x00005614bb68be80 in ev_eloop_dispatch (loop=loop@entry=0x5614eb3ed830, timeout=timeout@entry=-1) at ../kmscon/src/eloop.c:830
 #14 0x00005614bb68c53b in ev_eloop_run (loop=0x5614eb3ed830, timeout=-1) at ../kmscon/src/eloop.c:884
 #15 0x00005614bb67b8d6 in main (argc=<optimized out>, argv=<optimized out>) at ../kmscon/src/kmscon_main.c:616

Fixes https://github.com/kmscon/kmscon/issues/330