### PR TITLE
Support for terminal bell and keyboard LEDs

### DIFF
--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -417,6 +417,9 @@ typedef void (*tsm_vte_mouse_cb) (struct tsm_vte *vte,
 				  bool track_pixels,
 				  void *data);
 
+typedef void (*tsm_vte_bell_cb) (struct tsm_vte *vte,
+				 void *data);
+
 int tsm_vte_new(struct tsm_vte **out, struct tsm_screen *con,
 		tsm_vte_write_cb write_cb, void *data,
 		tsm_log_t log, void *log_data);
@@ -425,6 +428,7 @@ void tsm_vte_unref(struct tsm_vte *vte);
 
 void tsm_vte_set_osc_cb(struct tsm_vte *vte, tsm_vte_osc_cb osc_cb, void *osc_data);
 void tsm_vte_set_mouse_cb(struct tsm_vte *vte, tsm_vte_mouse_cb mouse_cb, void *mouse_data);
+void tsm_vte_set_bell_cb(struct tsm_vte *vte, tsm_vte_bell_cb bell_cb, void *bell_data);
 
 /**
  * @brief Set color palette to one of the predefined palette on the vte object.

--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -420,6 +420,16 @@ typedef void (*tsm_vte_mouse_cb) (struct tsm_vte *vte,
 typedef void (*tsm_vte_bell_cb) (struct tsm_vte *vte,
 				 void *data);
 
+enum tsm_vte_led {
+	TSM_VTE_LED_SCROLL_LOCK = (1 << 0),
+	TSM_VTE_LED_NUM_LOCK    = (1 << 1),
+	TSM_VTE_LED_CAPS_LOCK   = (1 << 2),
+};
+
+typedef void (*tsm_vte_led_cb) (struct tsm_vte *vte,
+				unsigned int leds,
+				void *data);
+
 int tsm_vte_new(struct tsm_vte **out, struct tsm_screen *con,
 		tsm_vte_write_cb write_cb, void *data,
 		tsm_log_t log, void *log_data);
@@ -429,6 +439,7 @@ void tsm_vte_unref(struct tsm_vte *vte);
 void tsm_vte_set_osc_cb(struct tsm_vte *vte, tsm_vte_osc_cb osc_cb, void *osc_data);
 void tsm_vte_set_mouse_cb(struct tsm_vte *vte, tsm_vte_mouse_cb mouse_cb, void *mouse_data);
 void tsm_vte_set_bell_cb(struct tsm_vte *vte, tsm_vte_bell_cb bell_cb, void *bell_data);
+void tsm_vte_set_led_cb(struct tsm_vte *vte, tsm_vte_led_cb led_cb, void *led_data);
 
 /**
  * @brief Set color palette to one of the predefined palette on the vte object.

--- a/src/tsm/libtsm.sym
+++ b/src/tsm/libtsm.sym
@@ -142,3 +142,9 @@ LIBTSM_4_4 {
 global:
 	tsm_vte_paste;
 } LIBTSM_4_3;
+
+LIBTSM_4_5 {
+global:
+	tsm_vte_set_bell_cb;
+	tsm_vte_set_led_cb;
+} LIBTSM_4_4;

--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -178,6 +178,9 @@ struct tsm_vte {
 	unsigned int mouse_last_row;
 	bool bracketed_paste;
 
+	tsm_vte_bell_cb bell_cb;
+	void *bell_data;
+
 	uint8_t (*custom_palette_storage)[3];
 	uint8_t (*palette)[3];
 	struct tsm_screen_attr def_attr;
@@ -576,6 +579,16 @@ void tsm_vte_set_mouse_cb(struct tsm_vte *vte, tsm_vte_mouse_cb mouse_cb, void *
 	vte->mouse_data = mouse_data;
 }
 
+SHL_EXPORT
+void tsm_vte_set_bell_cb(struct tsm_vte *vte, tsm_vte_bell_cb bell_cb, void *bell_data)
+{
+	if (!vte)
+		return;
+
+	vte->bell_cb = bell_cb;
+	vte->bell_data = bell_data;
+}
+
 static int vte_update_palette(struct tsm_vte *vte)
 {
 	vte->palette = get_palette(vte);
@@ -880,11 +893,8 @@ static void do_execute(struct tsm_vte *vte, uint32_t ctrl)
 		vte_write(vte, "\x06", 1);
 		break;
 	case 0x07: /* BEL */
-		/* Sound bell tone */
-		/* TODO: I always considered this annying, however, we
-		 * should at least provide some way to enable it if the
-		 * user *really* wants it.
-		 */
+		if (vte->bell_cb)
+			vte->bell_cb(vte, vte->bell_data);
 		break;
 	case 0x08: /* BS */
 		/* Move cursor one position left */

--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -181,6 +181,10 @@ struct tsm_vte {
 	tsm_vte_bell_cb bell_cb;
 	void *bell_data;
 
+	tsm_vte_led_cb led_cb;
+	void *led_data;
+	unsigned int led_state;
+
 	uint8_t (*custom_palette_storage)[3];
 	uint8_t (*palette)[3];
 	struct tsm_screen_attr def_attr;
@@ -587,6 +591,16 @@ void tsm_vte_set_bell_cb(struct tsm_vte *vte, tsm_vte_bell_cb bell_cb, void *bel
 
 	vte->bell_cb = bell_cb;
 	vte->bell_data = bell_data;
+}
+
+SHL_EXPORT
+void tsm_vte_set_led_cb(struct tsm_vte *vte, tsm_vte_led_cb led_cb, void *led_data)
+{
+	if (!vte)
+		return;
+
+	vte->led_cb = led_cb;
+	vte->led_data = led_data;
 }
 
 static int vte_update_palette(struct tsm_vte *vte)
@@ -2104,6 +2118,22 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 	case 'b': /* Repeat last char */
 		num = vte->csi_argv[0];
 		tsm_screen_repeat_char(vte->con, num);
+		break;
+	case 'q': /* DECLL - Load LEDs */
+		num = vte->csi_argv[0];
+		if (num <= 0) {
+			vte->led_state = 0;
+		} else if (num == 1) {
+			vte->led_state |= TSM_VTE_LED_SCROLL_LOCK;
+		} else if (num == 2) {
+			vte->led_state |= TSM_VTE_LED_NUM_LOCK;
+		} else if (num == 3) {
+			vte->led_state |= TSM_VTE_LED_CAPS_LOCK;
+		} else {
+			break;
+		}
+		if (vte->led_cb)
+			vte->led_cb(vte, vte->led_state, vte->led_data);
 		break;
 	default:
 		llog_debug(vte, "unhandled CSI sequence %c", data);

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -458,6 +458,97 @@ START_TEST(test_vte_csi_cursor_up_down)
 }
 END_TEST
 
+static bool bell_cb_called = false;
+
+static void bell_cb(struct tsm_vte *vte, void *data)
+{
+	bool *flag = data;
+	ck_assert_ptr_ne(vte, NULL);
+	if (flag)
+		*flag = true;
+	bell_cb_called = true;
+}
+
+START_TEST(test_vte_bell)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	tsm_vte_set_bell_cb(vte, bell_cb, NULL);
+
+	bell_cb_called = false;
+	tsm_vte_input(vte, "\x07", 1);
+	ck_assert(bell_cb_called);
+
+	/* BEL inside an OSC sequence acts as the ST terminator, not as a bell */
+	bell_cb_called = false;
+	tsm_vte_input(vte, "\033]0;title\x07", 10);
+	ck_assert(!bell_cb_called);
+
+	tsm_vte_unref(vte);
+	vte = NULL;
+
+	tsm_screen_unref(screen);
+	screen = NULL;
+}
+END_TEST
+
+START_TEST(test_vte_bell_no_cb)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	/* BEL without a registered callback must not crash */
+	tsm_vte_input(vte, "\x07", 1);
+
+	tsm_vte_unref(vte);
+	vte = NULL;
+
+	tsm_screen_unref(screen);
+	screen = NULL;
+}
+END_TEST
+
+START_TEST(test_vte_bell_data)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	bool flag = false;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	tsm_vte_set_bell_cb(vte, bell_cb, &flag);
+
+	tsm_vte_input(vte, "\x07", 1);
+	ck_assert(flag);
+
+	tsm_vte_unref(vte);
+	vte = NULL;
+
+	tsm_screen_unref(screen);
+	screen = NULL;
+}
+END_TEST
+
 TEST_DEFINE_CASE(misc)
 	TEST(test_vte_init)
 	TEST(test_vte_null)
@@ -470,10 +561,17 @@ TEST_DEFINE_CASE(misc)
 	TEST(test_vte_csi_cursor_up_down)
 TEST_END_CASE
 
+TEST_DEFINE_CASE(bell)
+	TEST(test_vte_bell)
+	TEST(test_vte_bell_no_cb)
+	TEST(test_vte_bell_data)
+TEST_END_CASE
+
 // clang-format off
 TEST_DEFINE(
 	TEST_SUITE(vte,
 		TEST_CASE(misc),
+		TEST_CASE(bell),
 		TEST_END
 	)
 )

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -567,11 +567,111 @@ TEST_DEFINE_CASE(bell)
 	TEST(test_vte_bell_data)
 TEST_END_CASE
 
+static unsigned int led_cb_leds = 0;
+static bool led_cb_called = false;
+
+static void led_cb(struct tsm_vte *vte, unsigned int leds, void *data)
+{
+	unsigned int *out = data;
+	ck_assert_ptr_ne(vte, NULL);
+	if (out)
+		*out = leds;
+	led_cb_leds = leds;
+	led_cb_called = true;
+}
+
+START_TEST(test_vte_led_decll)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	tsm_vte_set_led_cb(vte, led_cb, NULL);
+
+	/* CSI 1 q  — turn on Scroll Lock LED */
+	led_cb_called = false;
+	tsm_vte_input(vte, "\033[1q", 4);
+	ck_assert(led_cb_called);
+	ck_assert_uint_eq(led_cb_leds, TSM_VTE_LED_SCROLL_LOCK);
+
+	/* CSI 3 q  — turn on Caps Lock LED (cumulative) */
+	led_cb_called = false;
+	tsm_vte_input(vte, "\033[3q", 4);
+	ck_assert(led_cb_called);
+	ck_assert_uint_eq(led_cb_leds, TSM_VTE_LED_SCROLL_LOCK | TSM_VTE_LED_CAPS_LOCK);
+
+	/* CSI 0 q  — clear all LEDs */
+	led_cb_called = false;
+	tsm_vte_input(vte, "\033[0q", 4);
+	ck_assert(led_cb_called);
+	ck_assert_uint_eq(led_cb_leds, 0);
+
+	tsm_vte_unref(vte);
+	tsm_screen_unref(screen);
+}
+END_TEST
+
+START_TEST(test_vte_led_no_cb)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	/* DECLL without a registered callback must not crash */
+	tsm_vte_input(vte, "\033[1q", 4);
+
+	tsm_vte_unref(vte);
+	tsm_screen_unref(screen);
+}
+END_TEST
+
+START_TEST(test_vte_led_data)
+{
+	struct tsm_screen *screen;
+	struct tsm_vte *vte;
+	unsigned int out = 0;
+	int r;
+
+	r = tsm_screen_new(&screen, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, log_cb, NULL);
+	ck_assert_int_eq(r, 0);
+
+	tsm_vte_set_led_cb(vte, led_cb, &out);
+
+	tsm_vte_input(vte, "\033[2q", 4);
+	ck_assert_uint_eq(out, TSM_VTE_LED_NUM_LOCK);
+
+	tsm_vte_unref(vte);
+	tsm_screen_unref(screen);
+}
+END_TEST
+
+TEST_DEFINE_CASE(led)
+	TEST(test_vte_led_decll)
+	TEST(test_vte_led_no_cb)
+	TEST(test_vte_led_data)
+TEST_END_CASE
+
 // clang-format off
 TEST_DEFINE(
 	TEST_SUITE(vte,
 		TEST_CASE(misc),
 		TEST_CASE(bell),
+		TEST_CASE(led),
 		TEST_END
 	)
 )


### PR DESCRIPTION
These patches add support for bell and keyboard LEDs, there is an analogous PR in kmscon

Feedback welcome.

Disclaimer: these patches were assisted by Claude Opus 4.6 and audited by me.