### PR TITLE
screen: Fix wrong attribute for new cells when resizing

### DIFF
--- a/src/tsm/tsm-screen.c
+++ b/src/tsm/tsm-screen.c
@@ -1021,6 +1021,8 @@ void tsm_screen_set_def_attr(struct tsm_screen *con,
 	if (!con || !attr)
 		return;
 	memcpy(&con->def_attr, attr, sizeof(*attr));
+	if (!(con->flags & TSM_SCREEN_ALTERNATE))
+		memcpy(&con->def_attr_main, attr, sizeof(*attr));
 }
 
 SHL_EXPORT


### PR DESCRIPTION
When increasing the size of the terminal, the new cells are black, regardless of the current color attribute.
The resize code used def_main_attr, that can be unitialized.