### PR TITLE
Fix scrollback position

### DIFF
--- a/src/shared/shl_dlist.h
+++ b/src/shared/shl_dlist.h
@@ -105,6 +105,9 @@ static inline bool shl_dlist_empty(struct shl_dlist *head)
 #define shl_dlist_next(iter, head, member) \
 	((iter)->member.next == (head) ? NULL : shl_dlist_entry((iter)->member.next, typeof(*iter), list))
 
+#define shl_dlist_prev(iter, head, member) \
+	((iter)->member.prev == (head) ? NULL : shl_dlist_entry((iter)->member.prev, typeof(*iter), list))
+
 #define shl_dlist_for_each(iter, head) for (iter = (head)->next; iter != (head); iter = iter->next)
 
 #define shl_dlist_for_each_but_one(iter, start, head)                                              \

--- a/src/tsm/tsm-screen.c
+++ b/src/tsm/tsm-screen.c
@@ -222,7 +222,9 @@ static void link_to_scrollback(struct tsm_screen *con, struct line *line)
 		/* Only consider sb.max > 1, so there is always another line in sb. */
 		if (con->sb.pos == tmp) {
 			con->sb.pos = shl_dlist_first(&con->sb.list, struct line, list);
-			++con->sb.pos_num;
+			con->sb.pos_num = 0;
+		} else {
+			con->sb.pos_num--;
 		}
 		clear_selection_on_line(con, tmp);
 		line_free(tmp);
@@ -855,6 +857,8 @@ void tsm_screen_clear_sb(struct tsm_screen *con)
 SHL_EXPORT
 void tsm_screen_sb_up(struct tsm_screen *con, unsigned int num)
 {
+	struct line *prev;
+
 	if (!con || !num)
 		return;
 
@@ -870,8 +874,14 @@ void tsm_screen_sb_up(struct tsm_screen *con, unsigned int num)
 			if (con->sb.pos_num == 0)
 				return;
 
-			con->sb.pos = shl_dlist_last(&con->sb.pos->list, struct line, list);
+			prev = shl_dlist_prev(con->sb.pos, &con->sb.list, list);
+			if (!prev) {
+				llog_error(con, "prev is NULL, con->sb.pos_num: %d con->sb.count: %d",
+					   con->sb.pos_num, con->sb.count);
+				return;
+			}
 			--con->sb.pos_num;
+			con->sb.pos = prev;
 		} else {
 			con->sb.pos = shl_dlist_last(&con->sb.list, struct line, list);
 			con->sb.pos_num = con->sb.count - 1;

--- a/test/test_screen.c
+++ b/test/test_screen.c
@@ -257,6 +257,34 @@ START_TEST(test_screen_sb_get_line_pos)
 	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 3);
 	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 3);
 
+	tsm_screen_newline(screen);
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 4);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 4);
+
+	tsm_screen_newline(screen);
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 5);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 5);
+
+	tsm_screen_sb_up(screen, 2);
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 5);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 3);
+
+	tsm_screen_newline(screen);
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 5);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 2);
+
+	r = tsm_screen_resize(screen, 5, 3);
+	ck_assert_int_eq(r, 0);
+
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 5);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 0);
+
+	r = tsm_screen_resize(screen, 5, 5);
+	ck_assert_int_eq(r, 0);
+
+	ck_assert_int_eq(tsm_screen_sb_get_line_count(screen), 3);
+	ck_assert_int_eq(tsm_screen_sb_get_line_pos(screen), 0);
+
 	tsm_screen_unref(screen);
 	screen = NULL;
 }

--- a/test/test_selection.c
+++ b/test/test_selection.c
@@ -798,6 +798,26 @@ START_TEST(test_screen_copy_lines_sb_scrolled_cut_off)
 }
 END_TEST
 
+static void check_sb_pos(struct tsm_screen *screen)
+{
+	struct line *line = shl_dlist_first(&screen->sb.list, struct line, list);
+	int count = 0;
+
+	if (!screen->sb.pos) {
+		ck_assert_int_eq(screen->sb.pos_num, screen->sb.count);
+		return;
+	}
+
+	ck_assert_int_le(screen->sb.pos_num, screen->sb.count);
+
+	while (line && line != screen->sb.pos) {
+		count++;
+		line = shl_dlist_next(line, &screen->sb.list, list);
+	}
+
+	ck_assert_int_eq(count, screen->sb.pos_num);
+}
+
 static void write_random_string(struct tsm_screen *screen, int count)
 {
 	char str[201];
@@ -834,14 +854,18 @@ START_TEST(test_screen_robustness)
 
 	write_random_string(screen, 600);
 
+	check_sb_pos(screen);
+
 	for (i = 0; i < 300; i++) {
 		size_x =  1 + rand() % 100;
 		size_y =  1 + rand() % 100;
 		r = tsm_screen_resize(screen, size_x, size_y);
 		ck_assert_int_eq(r, 0);
-		
-		tsm_screen_scroll_up(screen, rand() % sb_size);
-		tsm_screen_scroll_down(screen, rand() % sb_size);
+		check_sb_pos(screen);
+		tsm_screen_sb_up(screen, rand() % sb_size);
+		check_sb_pos(screen);
+		tsm_screen_sb_down(screen, rand() % sb_size);
+		check_sb_pos(screen);
 		tsm_screen_selection_start(screen, rand() % size_x, rand() % size_y);
 		tsm_screen_selection_target(screen, rand() % size_x, rand() % size_y);
 		for (j = 0; j < 50; j++) {
@@ -851,8 +875,10 @@ START_TEST(test_screen_robustness)
 				free(str);
 				str = NULL;
 			}
-			tsm_screen_scroll_up(screen, rand() % sb_size);
-			tsm_screen_scroll_down(screen, rand() % sb_size);
+			tsm_screen_sb_up(screen, sb_size );
+			check_sb_pos(screen);
+			tsm_screen_sb_down(screen, rand() % sb_size);
+			check_sb_pos(screen);
 		}
 		write_random_string(screen, rand() % 100);
 	}


### PR DESCRIPTION
sb.pos, sb.pos_num and sb.count must stay coherent.
Fix the few corner case where sb.pos_num can be greater than sb.count.

Fix: https://github.com/kmscon/kmscon/issues/330