### PR TITLE
fix CSI default parameter

### DIFF
--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -1056,8 +1056,12 @@ static void do_param(struct tsm_vte *vte, uint32_t data)
 	int new;
 
 	if (data == ';') {
-		if (vte->csi_argc < CSI_ARG_MAX)
+		if (vte->csi_argc < CSI_ARG_MAX) {
+			// default parameter value is 0 if omitted
+			if (vte->csi_argv[vte->csi_argc] == -1)
+				vte->csi_argv[vte->csi_argc] = 0;
 			vte->csi_argc++;
+		}
 		return;
 	}
 


### PR DESCRIPTION
if a parameter is omitted, it should be set to 0.

So the following sequences should be equivalent:
\x1b[0;90m
\x1b[;90m

And with this fix, they are now equivalent.

Fixes #46 