### PR TITLE
Fix: also clear the character value for multi-width character.

### DIFF
--- a/src/tsm/tsm-screen.c
+++ b/src/tsm/tsm-screen.c
@@ -405,6 +405,7 @@ static void screen_write(struct tsm_screen *con, unsigned int x,
 	for (i = 1; i < len && i + x < con->size_x; ++i) {
 		line->cells[x + i].age = con->age_cnt;
 		line->cells[x + i].width = 0;
+		line->cells[x + i].ch = 0;
 	}
 }
 


### PR DESCRIPTION
When writing a character with a len of two or more, the cells are not cleared properly, leading to the previous character being visible. This is easily reproduced with tmux and CJK text.

Fix #55 