### PR TITLE
libtsm: fix tsm_screen_attr2_t

### DIFF
--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -180,7 +180,7 @@ typedef union{
 		uint8_t italic    : 1;
 		uint8_t underline : 1;
 		uint8_t blink     : 1;
-		uint8_t reserved  : 5;
+		uint8_t reserved  : 4;
 	};
 	uint8_t u8;
 } tsm_screen_attr2_t;


### PR DESCRIPTION
Fix typo, reserved should be 4 bits, so that the struct is 1 byte.